### PR TITLE
Add bang functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## v0.2.0 (2021-04-24)
+
+### Enhancements
+
+  * Add `build!/2`
+  * Add `build_list!/3`
+  * Add `insert!/3`
+  * Add `insert_list!/4`
+
+All the new functions raise `EctoStreamFactory.MissingKeyError` error if a generated struct, map or keyword list cannot be fully merged with the provided attributes.

--- a/README.md
+++ b/README.md
@@ -126,8 +126,11 @@ iex> build(:post, text: "Hello world")
 iex> build_list(2, :user, name: fn n -> "user#{n}" end)
 [%User{id: nil, name: "user1", age: 51, email: "n5@gmail.com"}, %User{id: nil, name: "user2", age: 40, email: "O6@yandex.com"}]
 
-iex> insert(:user)
+iex> insert!(:user)
 %User{id: 1, name: "b", age: 23, email: "az7@gmail.com"}
+
+iex> insert!(:user, gender: "female")
+** (EctoStreamFactory.MissingKeyError) MyApp.Factory.user_generator does not generate :gender field.
 
 iex> insert(:user, [email: "az7@gmail.com"], on_conflict: :nothing)
 %User{id: nil, name: "c", age: 44, email: "az7@gmail.com"}

--- a/lib/ecto_stream_factory/ecto_stream_factory.ex
+++ b/lib/ecto_stream_factory/ecto_stream_factory.ex
@@ -32,26 +32,47 @@ defmodule EctoStreamFactory do
 
       @repo Factory.get_repo(__MODULE__, opts)
 
-      def build(generator_name, attrs \\ [])
-          when is_atom(generator_name) or is_binary(generator_name) do
+      defguardp is_valid_generator_name(value) when is_atom(value) or is_binary(value)
+      defguardp is_valid_amount(value) when is_integer(value) and value > 0
+
+      def build(generator_name, attrs \\ []) when is_valid_generator_name(generator_name) do
         Factory.build(__MODULE__, generator_name, attrs)
       end
 
+      def build!(generator_name, attrs \\ []) when is_valid_generator_name(generator_name) do
+        Factory.build!(__MODULE__, generator_name, attrs)
+      end
+
       def build_list(amount, generator_name, attrs \\ [])
-          when (is_atom(generator_name) or is_binary(generator_name)) and
-                 (is_integer(amount) and amount > 0) do
+          when is_valid_generator_name(generator_name) and
+                 is_valid_amount(amount) do
         Factory.build_list(__MODULE__, amount, generator_name, attrs)
       end
 
+      def build_list!(amount, generator_name, attrs \\ [])
+          when is_valid_generator_name(generator_name) and
+                 is_valid_amount(amount) do
+        Factory.build_list!(__MODULE__, amount, generator_name, attrs)
+      end
+
       def insert(generator_name, attrs \\ [], opts \\ [])
-          when is_atom(generator_name) or is_binary(generator_name) do
+          when is_valid_generator_name(generator_name) do
         Factory.insert(__MODULE__, @repo, generator_name, attrs, opts)
       end
 
+      def insert!(generator_name, attrs \\ [], opts \\ [])
+          when is_valid_generator_name(generator_name) do
+        Factory.insert!(__MODULE__, @repo, generator_name, attrs, opts)
+      end
+
       def insert_list(amount, generator_name, attrs \\ [], opts \\ [])
-          when (is_atom(generator_name) or is_binary(generator_name)) and
-                 (is_integer(amount) and amount > 0) do
+          when is_valid_generator_name(generator_name) and is_valid_amount(amount) do
         Factory.insert_list(__MODULE__, @repo, amount, generator_name, attrs, opts)
+      end
+
+      def insert_list!(amount, generator_name, attrs \\ [], opts \\ [])
+          when is_valid_generator_name(generator_name) and is_valid_amount(amount) do
+        Factory.insert_list!(__MODULE__, @repo, amount, generator_name, attrs, opts)
       end
     end
   end
@@ -73,9 +94,9 @@ defmodule EctoStreamFactory do
   @type insert_opts() :: Keyword.t()
 
   @doc """
-  Takes a signle instance from a StreamData [gen/1](`ExUnitProperties.gen/1`) generator.
+  Takes a single instance from a StreamData [gen/1](`ExUnitProperties.gen/1`) generator.
 
-  If the generator returs a struct, map or keyword list, it also merges the result with the provided overwrites.
+  If the generator returs a struct, map or keyword list, it also merges the result with `overwrites`.
 
   ## Examples
 
@@ -87,6 +108,19 @@ defmodule EctoStreamFactory do
   """
   @callback build(generator_name(), overwrites()) :: term()
 
+  @doc """
+  Same as `c:build/2`, but raises an error if some key in `overwrites` does not exist in the generated struct, map or keyword list.
+
+  ## Examples
+
+      iex> Factory.build!(:user)
+      %User{id: nil, name: "b", age: 28}
+
+      iex> Factory.build!(:user, name: "foo", weight: 101)
+      ** (EctoStreamFactory.MissingKeyError) MyApp.Factory.user_generator does not generate :weight field.
+  """
+  @callback build!(generator_name(), overwrites()) :: term()
+
   @doc ~S"""
   Same as `c:build/2`, but instantiates a list of structs.
 
@@ -96,6 +130,11 @@ defmodule EctoStreamFactory do
       [%User{id: nil, name: "user1"}, %User{id: nil, name: "user2"}]
   """
   @callback build_list(amount(), generator_name(), overwrites) :: nonempty_list(term())
+
+  @doc ~S"""
+  Same as `c:build_list/3`, but raises an error if some key in `overwites` does not exist in the generated entities.
+  """
+  @callback build_list!(amount(), generator_name(), overwrites) :: nonempty_list(term())
 
   @doc """
   Similar to `c:build/2`, but expects a generator to return an Ecto.Schema struct to insert it into the database.
@@ -108,6 +147,11 @@ defmodule EctoStreamFactory do
   @callback insert(generator_name(), overwrites(), insert_opts()) :: Schema.t()
 
   @doc """
+  Same as `c:insert/3`, but raises an error if some key in `overwites` does not exist in the generated struct.
+  """
+  @callback insert!(generator_name(), overwrites(), insert_opts()) :: Schema.t()
+
+  @doc """
   Same as `c:insert/3`, but inserts a list of structs.
 
   ## Examples
@@ -116,5 +160,11 @@ defmodule EctoStreamFactory do
       [%User{id: 3, role: "admin"}, %User{id: 4, role: "admin"}, %User{id: 5, role: "admin"}]
   """
   @callback insert_list(amount(), generator_name(), overwrites(), insert_opts()) ::
+              nonempty_list(Schema.t())
+
+  @doc ~S"""
+  Same as `c:insert_list/4`, but raises an error if some key in `overwites` does not exist in the generated structs.
+  """
+  @callback insert_list!(amount(), generator_name(), overwrites(), insert_opts()) ::
               nonempty_list(Schema.t())
 end

--- a/lib/ecto_stream_factory/exceptions.ex
+++ b/lib/ecto_stream_factory/exceptions.ex
@@ -1,6 +1,4 @@
 defmodule EctoStreamFactory.UndefinedGeneratorError do
-  @moduledoc false
-
   defexception [:module, :generator_name]
 
   @impl true
@@ -9,7 +7,7 @@ defmodule EctoStreamFactory.UndefinedGeneratorError do
     No generator defined for #{inspect(gen_name)}.
     Please check for typos or define your generator:
 
-        defmodule #{module} do
+        defmodule #{inspect(module)} do
           def #{EctoStreamFactory.Factory.function_from_generator_name(gen_name)} do
             ...
           end
@@ -19,8 +17,6 @@ defmodule EctoStreamFactory.UndefinedGeneratorError do
 end
 
 defmodule EctoStreamFactory.RepoNotSpecifiedError do
-  @moduledoc false
-
   defexception [:module]
 
   @impl true
@@ -30,10 +26,21 @@ defmodule EctoStreamFactory.RepoNotSpecifiedError do
     """
     :repo option is missing. Please configure the factory:
 
-        defmodule #{module} do
+        defmodule #{inspect(module)} do
           use EctoStreamFactory, repo: #{repo_module}.Repo
           ...
         end
+    """
+  end
+end
+
+defmodule EctoStreamFactory.MissingKeyError do
+  defexception [:module, :generator_name, :key]
+
+  @impl true
+  def message(%{module: module, generator_name: gen_name, key: key}) do
+    """
+    #{inspect(module)}.#{EctoStreamFactory.Factory.function_from_generator_name(gen_name)} does not generate #{inspect(key)} field.
     """
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule EctoStreamFactory.MixProject do
   def project do
     [
       app: :ecto_stream_factory,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: ">= 1.10.0",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/support/test_factory.ex
+++ b/test/support/test_factory.ex
@@ -4,7 +4,7 @@ defmodule EctoStreamFactory.TestFactory do
   def user_generator do
     gen all name <- string(:alphanumeric, min_length: 1),
             email <- email_generator(),
-            age <- integer(15..80) do
+            age <- integer(18..80) do
       %EctoStreamFactory.User{name: name, email: email, age: age}
     end
   end
@@ -26,14 +26,14 @@ defmodule EctoStreamFactory.TestFactory do
   def map_generator do
     gen all field1 <- string(:alphanumeric, min_length: 1),
             field2 <- integer() do
-      %{fiel1: field1, field2: field2}
+      %{field1: field1, field2: field2}
     end
   end
 
   def keyword_generator do
     gen all field1 <- string(:alphanumeric, min_length: 1),
             field2 <- integer() do
-      [fiel1: field1, field2: field2]
+      [field1: field1, field2: field2]
     end
   end
 


### PR DESCRIPTION
The main purpose of the bang version of the functions is to prevent silly typos that might waste developers time on debugging.
```elixir
insert(:user, naame: "foo") # I expected name to be "foo", but my overwrites were ignored due to a typo
```